### PR TITLE
Explicitly use unicode strings to encode arguments and inputs

### DIFF
--- a/chrome.py
+++ b/chrome.py
@@ -130,8 +130,8 @@ if __name__ == '__main__':
     arguments = docopt(__doc__, version='Alfred Chrome History {}'.format(__version__))
     favicons = arguments.get('--no-favicons') is False
 
-    profile = arguments.get('PROFILE')
-    query = arguments.get('QUERY')
+    profile = unicode(arguments.get('PROFILE'), encoding='utf-8', errors='ignore')
+    query = unicode(arguments.get('QUERY'), encoding='utf-8', errors='ignore')
 
     try:
         db = history_db(profile, favicons=favicons)


### PR DESCRIPTION
This should address #16, but in a (hopefully) slightly more robust way
We were using unicode strings everywhere else, so this shouldn't have
much impact on anything "downstream"; ie queries should still be fine.