### PR TITLE
Update workflow to support python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 *.py
 *.pyc
 !chrome.py
+!alfred.py

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ distclean :
 	rm -f ./alfred-chrome-history.alfredworkflow
 
 clean :
-	rm -f alfred.py
 	rm -f docopt.py
 	rm -rf ${VENV}
 	find . -iname "*.pyc" -delete
@@ -21,11 +20,10 @@ venv/bin/activate : requirements.txt
 
 install : venv
 	. ${VENV}/bin/activate
-	pip install -r requirements.txt --upgrade --force-reinstall
+	pip3 install -r requirements.txt --upgrade --force-reinstall
 
 lib :
-	cp `python sitepackages.py`/alfred.py alfred.py
-	cp `python sitepackages.py`/docopt.py docopt.py
+	cp `python3 sitepackages.py`/docopt.py docopt.py
 
 dev : install \
 	lib

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Alfred script filter is set up to use the default Chrome profile located in 
 ```sh
 PROFILE="~/Library/Application Support/Google/Chrome/Profile 1"
 PATH="env/bin:$PATH"
-python chrome.py "${PROFILE}" "{query}"
+python3 chrome.py "${PROFILE}" "{query}"
 ```
 
 In a terminal, the following command can help you find the exact location of the profile directory that the workflow needs:
@@ -41,7 +41,7 @@ ls ~/Library/Application\ Support/Google/Chrome/ | grep Profile
 By default, the script tries to grab favicons from a separate database. This can sometimes slow down the results, which is not desirable. To turn off favicon support, pass `--no-favicons` in the Alfred workflow's script filter. The last line of the script should look like the following:
 
 ```sh
-python chrome.py "${PROFILE}" "{query}" --no-favicons
+python3 chrome.py "${PROFILE}" "{query}" --no-favicons
 ```
 
 ## How to build

--- a/alfred.py
+++ b/alfred.py
@@ -1,0 +1,96 @@
+import itertools
+import os
+import plistlib
+import unicodedata
+import sys
+
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+UNESCAPE_CHARACTERS = " ;()"
+
+_MAX_RESULTS_DEFAULT = 9
+
+# Updated to use plistlib.load for Python 3 compatibility
+with open('info.plist', 'rb') as fp:
+    preferences = plistlib.load(fp)
+bundleid = preferences['bundleid']
+
+class Item:
+    @classmethod
+    def unicode(cls, value):
+        try:
+            items = iter(value.items())
+        except AttributeError:
+            # Directly return the value if it's not a dict
+            return str(value)
+        else:
+            # Use str instead of unicode for Python 3 compatibility
+            return dict(map(cls.unicode, item) for item in items)
+
+    def __init__(self, attributes, title, subtitle, icon=None):
+        self.attributes = attributes
+        self.title = title
+        self.subtitle = subtitle
+        self.icon = icon
+
+    def __str__(self):
+        return tostring(self.xml()).decode('utf-8')
+
+    def xml(self):
+        item = Element('item', self.unicode(self.attributes))
+        for attribute in ('title', 'subtitle', 'icon'):
+            value = getattr(self, attribute)
+            if value is None:
+                continue
+            if len(value) == 2 and isinstance(value[1], dict):
+                (value, attributes) = value
+            else:
+                attributes = {}
+            SubElement(item, attribute, self.unicode(attributes)).text = self.unicode(value)
+        return item
+
+def args(characters=None):
+    return tuple(unescape(decode(arg), characters) for arg in sys.argv[1:])
+
+def config():
+    return _create('config')
+
+def decode(s):
+    # Removed .decode('utf-8') as strings are already Unicode in Python 3
+    return unicodedata.normalize('NFD', s)
+
+def env(key):
+    return os.environ[f'alfred_{key}']
+
+def uid(uid):
+    return '-'.join(map(str, (bundleid, uid)))
+
+def unescape(query, characters=None):
+    for character in (UNESCAPE_CHARACTERS if (characters is None) else characters):
+        query = query.replace(f'\\{character}', character)
+    return query
+
+def work(volatile):
+    path = {
+        True: env('workflow_cache'),
+        False: env('workflow_data')
+    }[bool(volatile)]
+    return _create(path)
+
+def write(text):
+    if isinstance(text, bytes):
+        text = text.decode('utf-8')
+    sys.stdout.write(text)
+
+def xml(items, maxresults=_MAX_RESULTS_DEFAULT):
+    root = Element('items')
+    for item in itertools.islice(items, maxresults):
+        root.append(item.xml())
+    return tostring(root, encoding='utf-8')
+
+def _create(path):
+    if not os.path.isdir(path):
+        os.mkdir(path)
+    if not os.access(path, os.W_OK):
+        raise IOError(f'No write access: {path}')
+    return path

--- a/info.plist
+++ b/info.plist
@@ -93,9 +93,9 @@
 				<key>runningsubtext</key>
 				<string>Searching...</string>
 				<key>script</key>
-				<string>PROFILE="~/Library/Application Support/Google/Chrome/Default"
+				<string>PROFILE="~/Library/Application Support/Google/Chrome/Profile 1"
 PATH="env/bin:$PATH"
-python chrome.py "${PROFILE}" "{query}"</string>
+python3 chrome.py "${PROFILE}" "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>
@@ -147,7 +147,7 @@ The Alfred script filter is set up to use the default Chrome profile located in 
 
 PROFILE="~/Library/Application Support/Google/Chrome/Profile 1"
 PATH="env/bin:$PATH"
-python chrome.py "${PROFILE}" "{query}"
+python3 chrome.py "${PROFILE}" "{query}"
 In a terminal, the following command can help you find the exact location of the profile directory that the workflow needs:
 
 ls ~/Library/Application\ Support/Google/Chrome/ | grep Profile</string>
@@ -156,25 +156,27 @@ ls ~/Library/Application\ Support/Google/Chrome/ | grep Profile</string>
 		<key>28DD6FE4-9B8F-404F-858E-31FB8159BDAF</key>
 		<dict>
 			<key>xpos</key>
-			<integer>700</integer>
+			<real>700</real>
 			<key>ypos</key>
 			<real>130</real>
 		</dict>
 		<key>B8584F68-2E3A-4883-AE38-1F31EE5C2657</key>
 		<dict>
 			<key>xpos</key>
-			<integer>700</integer>
+			<real>700</real>
 			<key>ypos</key>
-			<real>10</real>
+			<real>15</real>
 		</dict>
 		<key>F5EE6337-C93B-44AE-9DB3-C9C1C204D42F</key>
 		<dict>
 			<key>xpos</key>
-			<integer>300</integer>
+			<real>300</real>
 			<key>ypos</key>
-			<real>10</real>
+			<real>15</real>
 		</dict>
 	</dict>
+	<key>userconfigurationconfig</key>
+	<array/>
 	<key>version</key>
 	<string>0.8.0</string>
 	<key>webaddress</key>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+git://github.com/nikipore/alfred-python.git
 docopt==0.6.2


### PR DESCRIPTION
Update workflow to support python3 

### Why? 

`python` is deprecated. Let's update the workflow to use python3 instead 

### Changes 

- Update `chrome.py` to use python3 commands 
- Define `alfred.py` directly into `alfred-chrome-history` instead of importing. They don't seem to support python3. 